### PR TITLE
make front page wording a bit more constistent with plural candidates

### DIFF
--- a/democracy_club/templates/home.html
+++ b/democracy_club/templates/home.html
@@ -40,7 +40,7 @@
 
   <section class="box_widget">
     <header>
-      <h3><span class="task_number">3</span> Read your <br>Candidate's CV</h3>
+      <h3><span class="task_number">3</span> Read your <br>candidates' CVs</h3>
     </header>
     <p>
       Use <a href="http://cv.democracyclub.org.uk">MPCV</a> to read the CV of your
@@ -52,10 +52,10 @@
 
   <section class="box_widget">
     <header>
-      <h3><span class="task_number">4</span> Read about your candidate or area</h3>
+      <h3><span class="task_number">4</span> Read the press about<br/>your candidates or area</h3>
     </header>
     <p>
-      <a href="http://ElectionMentions.com">Election Mentions</a> presents articles that we think are relevant in an attractive
+      <a href="http://ElectionMentions.com">Election Mentions</a> presents press articles that we think are relevant in an attractive
       and simple list, facilitating further research, and ultimately helping to
       inform your vote. You can also add articles you find for other people to read.
       </p>


### PR DESCRIPTION
Tweaking front page copy to make it a bit more consistent, so all mentions are of candidates (plural), etc. Also fix spillover of number 4.