### PR TITLE
Revise polling station project mini-site

### DIFF
--- a/democracy_club/templates/polling-stations/home.html
+++ b/democracy_club/templates/polling-stations/home.html
@@ -26,7 +26,6 @@ We work with local government to establish internal best practice for publishing
 * Finds the polling station assigned to a property, not the closest one
 * Doesn't require voters to know their way around local government
 * Supports postcode areas that overlap district boundaries
-* Updates automatically when the underlying data changes*
 * Supports last minute changes, in the case of emergencies and closed polling stations
 * Embeddable in your web site
 * Fully customisable and white-label versions on request
@@ -34,14 +33,11 @@ We work with local government to establish internal best practice for publishing
 * High performance and scalability ensures uptime on the busiest of elections
 * Fully featured API
 
-\* If the data is provided to Gold+ and Silver+ standards (see [Technical specification]({% url "polling_technical_explainer" %}))
-
 
 {% endfilter %}
 
-<a href="{% url "polling_data_upload" %}" class="link-button">Upload your data</a>
-<p>Work for local government? Upload your data to the
-    platform and help people find out where to vote</p>
+<a href="{% url "polling_data_upload" %}" class="link-button">Send us data</a>
+<p>Work for local government? Send us your data to help people find out where to vote</p>
 <a href="{% url "polling_embed_code"%}" class="link-button">Embed on your web site</a>
 <p>Get the embed code to add a polling station finder to your own site</p>
 

--- a/democracy_club/templates/polling-stations/polling_stations_base.html
+++ b/democracy_club/templates/polling-stations/polling_stations_base.html
@@ -7,9 +7,8 @@
       <ul>
         <li><a href="{% url "polling_one_pager" %}">Overview</a></li>
         <li><a href="{% url "polling_faqs" %}">FAQs</a></li>
-        <li><a href="{% url "polling_technical_explainer" %}">Technical specification</a></li>
         <li><a href="{% url "polling_embed_code" %}">Embed code</a></li>
-        <li><a class="link-button" href="{% url "polling_data_upload" %}">Upload Data</a></li>
+        <li><a href="{% url "polling_data_upload" %}">Send us Data</a></li>
       </ul>
     </nav>
 

--- a/democracy_club/templates/polling-stations/upload_data.html
+++ b/democracy_club/templates/polling-stations/upload_data.html
@@ -2,25 +2,16 @@
 {% load django_markdown %}
 
 {% block page_title %}
-<h1>Upload data</h1>
+<h1>Send us data</h1>
 {% endblock page_title %}
 
 
 {% block main_content %}
 {% filter markdown %}
 
-**To send us data, please email the data or a link to the hosted version to [pollingstations@democracyclub.org.uk](mailto:pollingstations@democracyclub.org.uk).**
+**To send us data, please email the data to [pollingstations@democracyclub.org.uk](mailto:pollingstations@democracyclub.org.uk).**
 
-Please read our
-[technical guide]({% url "polling_technical_explainer" %}) before sending the data over.
-
-## 'Plus'-standard data
-
-If you're able to publish Gold Plus or Silver Plus data, then all we need are the URLs for the data.
-
-Please make sure that these URLs will be updated as the data changes. We have systems for checking
-updates and flagging when we think
-the data should have changed, but it's best to double check the internet IT process in your authority too.
+Please send us new data for each election, or confirm that it has not changed.
 
 ## Exporting from your EMS
 
@@ -32,23 +23,18 @@ There is a Knowledge Base Article (KBA) about how to export data. Click on "Demo
 
 ### Xpress
 
-The Democracy Club report is in "Express Management" under "Elections/Exports" and the report is called ‘EC & Democracy Club Polling Place Lookup’.
+The Democracy Club report is in "Express Management" under "Elections/Exports" and the report is called "EC &amp; Democracy Club Polling Place Lookup".
 
 ### Democracy Counts / Elector8
 
-For Elector8 Users, go to Planning & Reporting > Category Searches and select both of the following:
+For Elector8 Users, go to "Planning &amp; Reporting" then "Category Searches" and select both of the following:
 
-* Democracy Club - Polling  Districts
+* Democracy Club - Polling Districts
 * Democracy Club - Polling Stations
 
 ### Idox
 
-Unfortunately Idox haven't provided an easy export yet, but they are working on it. It's worth <a href="{% url "contact" %}">getting in touch with us</a> anyway, as we might be able to work with your GIS team on getting Gold or Gold+ standard data.
-
-
-## Gold and Silver standard data
-
-For accuracy, we only use data for one election. Please send us new data for each election, or confirm that it has not changed.
+Unfortunately Idox haven't provided an easy export yet, but they are working on it. It's worth <a href="{% url "contact" %}">getting in touch with us</a> anyway, as we might be able to work with your GIS team on getting data.
 
 
 {% endfilter %}


### PR DESCRIPTION
Closes #64

It would be great if everyone was publishing consistently updated GIS data via APIs and stuff, but since we wrote this guidance, things have changed...
* Experience has taught us that GIS data is:
  * Slower for us to work with
  * More difficult for most councils to provide
  * Much more prone to errors than EMS exports
* Now 3 of the 4 suppliers of Electoral Management software have an 'export to Democracy Club' button in them :D

This PR updates the WhereDoIVote mini-site to reflect this by making the following changes:
* Upload --> Send
* Remove links to tech guidance, references to gold+silver, etc
* Make the ask really simple and clear:
  * press these buttons
  * send us the stuff
* Bit of tidying (consistent quotes, html escaping)

For the moment I have left the 'technical' route/template in there but removed the link from the menu. We can still link someone directly to https://democracyclub.org.uk/projects/polling-stations/technical/ if we need to. I think it is still useful to have that available in case someone wants to provide us with an API or uses Idox and refers us to their GIS team or whatever.. we probably need to revise it a bit long-term, but for the moment I think leaving it as a 'secret' link is ok?

Thoughts?