### PR TITLE
Copy edits

### DIFF
--- a/democracy_club/apps/report_2018/templates/report_2018/report.html
+++ b/democracy_club/apps/report_2018/templates/report_2018/report.html
@@ -136,7 +136,7 @@ this information to the elections data.
 ### Partners
 There were no partners who used the elections data.
 ### Reach/use
-This dataset was used every time a postcode lookup was made via a Democracy Club service — that is, 989,000 times for
+This dataset was used every time a postcode lookup was made via a Democracy Club service — that is, 1.1m times for
 the 3 May elections.
 ### Analysis
 Our ability to cover all elections, with more notice, is due to at least two factors. In previous years, much of this
@@ -220,10 +220,7 @@ We were able to provide users in 126 of the 152 local authorities with scheduled
 location. That means we covered 87% of the 18+ population in areas with a scheduled election, up from 61% at the 2017
 general election.
 ### Partners
-The data was used by:
-The Electoral Commission’s Your Vote Matters website
-The Labour Party
-Democratic Dashboard (a project from the London School of Economics / Democratic Audit)
+The data was used by: The Electoral Commission’s Your Vote Matters website, the Labour Party, and Democratic Dashboard (a project from the London School of Economics / Democratic Audit).
 ### Reach/use
 There were 615,995 searches for polling locations at the May elections. These were mostly served by partners via our
 API.
@@ -317,7 +314,7 @@ coverage for the 2019 elections.
 ## Results data
 
 ### Coverage
-In a first for Democracy Club, volunteers were able to collect results for every candidate at the scheduled elections
+In a first for Democracy Club, volunteers managed to collect the vote count for every candidate at the scheduled elections
 in May. Where possible, volunteers also collected turnout data, but because this is not statutorily required, many
 councils do not publish it or there are differences in how councils report it.
 ### Partners / usage
@@ -431,7 +428,7 @@ elections they had, and which type, and sent emails based on this. The lists wer
 were well-received: open rates were around 50% with click-through rates varying from 11% to 27%.
 
 ## ODI Registers Report
-The Open Data Institute commissioned us and <a href="http://openhealthcare.org.uk/">Open Health Care</a>
+  The <a href="https://theodi.org/">Open Data Institute</a> commissioned us and <a href="http://openhealthcare.org.uk/">Open Health Care</a>
   to research and produce a report on collaborative
 registers (our candidates lists could be understood this way).
   You can <a href="https://theodi.org/article/registers-and-collaboration-making-lists-we-can-trust-report/">read it here</a>.
@@ -467,7 +464,7 @@ elections. Our 2017/2018 funders were The Electoral Commission and Unbound Phila
 We will now work to set a range of goals for the next election year, have a plan in place for a snap general election
 and also aim to think longer-term about our goals and our places in the civic participation ecosystem.
 
-The goals set for 2017/2018 were mostly achieved — if we exclude the Labs goals — which suggests we had a relatively
+As the scorecard appended below shows, the goals we set for 2017/2018 were mostly achieved — if we exclude the ideas we had for Labs — which suggests we had a relatively
 good sense of what was realistic. However, there were elements left behind that clearly indicate the need for extra
 resource even in the short term: growing the community and club, research and diversity.
 
@@ -481,7 +478,7 @@ to raise money to use our knowledge to become an effective funder of democratic 
 As always, we welcome new ideas to consider or new problems to solve. We will host
   <a href="https://attending.io/events/democracy-club-summer-2018-meetup">a summer get-together on Saturday
     23 June in Manchester</a>: please come along with any ideas, reflections or just to hang out. Alternatively you can email
-us, tweet us or make specific issue requests about our products via Github.
+  us, <a href="https://twitter.com/democlub">tweet us</a> or make specific issue requests about our products via <a href="https://github.com/DemocracyClub/">Github</a>.
 
 # Acknowledgements
 <img src="{% static "report_2018/images/benjamin-elliott-670761-unsplash.jpg" %}">
@@ -682,7 +679,7 @@ The table below reviews our progress against those goals.
     <tr>
       <td>Help 250,000 people engage with election information across Data and Apps</td>
       <td class="met">Met</td>
-      <td>989,000 total hits to the API (NB. This includes repeat uses by the same person.)</td>
+      <td>1.1m total hits to the APIs (NB. This includes repeat uses by the same person.)</td>
     </tr>
     <tr>
       <td>Greater percentage of users find Who and Where useful (vs 2016 previous comparable elections)</td>


### PR DESCRIPTION
- I'd undercounted PSF api hits (had used 500k, instead of actual 616k) in the elections API usage figures and 'big general number' figure (so 1.1m instead of 989k)
- The list of users of PSF data was looking odd, so made it a sentence.
- Results data first sentence clarification
- Link to ODI website
- Mention of 'scorecard below' in relevant section
- Contact us links added
- Total number of API hits updated in the scorecard table