### PR TITLE
zappa deploy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ region = eu-west-2
 
 Zappa requires an active, local virtualenv. It's best to make one for production and one for local dev. A production env will be smaller and wont deploy all the testing packages.
 
-To deploy, run `deploy.sh [dev|prod]`
+To deploy:
+
+* `export AWS_PROFILE=dc`
+* `deploy.sh [dev|prod]`
 
 This will:
 
@@ -35,6 +38,7 @@ This will:
 2. runs `zappa update`
 3. Migrates Django and collects static
 
+If the build fails, run `zappa tail [dev|prod] --since SINCE` to [tail the log](https://github.com/Miserlou/Zappa#tailing-logs) and debug the build.
 
 ## Cron / scheduling / events
 

--- a/democracy_club/apps/core/__init__.py
+++ b/democracy_club/apps/core/__init__.py
@@ -1,0 +1,18 @@
+import storages
+from django.apps import apps
+from django.core.checks import Error, register
+
+@register()
+def check_django_storage_version(app_configs, **kwargs):
+    errors = []
+    if (app_configs is None or apps.get_app_config('core') in app_configs):
+        if storages.__version__ != '1.6.5':
+            errors.append(
+                Error(
+                    'django-storages must be at version 1.6.5',
+                    hint='See https://github.com/DemocracyClub/Website/pull/117',
+                    obj='core',
+                    id='core.E001'
+                )
+            )
+    return errors

--- a/democracy_club/settings/base.py
+++ b/democracy_club/settings/base.py
@@ -99,6 +99,7 @@ INSTALLED_APPS = (
 )
 
 PROJECT_APPS = (
+    'core',
     'dc_members',
     'hermes',
     'typogrify',

--- a/democracy_club/settings/base.py
+++ b/democracy_club/settings/base.py
@@ -86,7 +86,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
-    'django.contrib.gis',
     'localflavor',
     'markdown_deux',
     'django_extensions',

--- a/democracy_club/settings/base.py
+++ b/democracy_club/settings/base.py
@@ -19,7 +19,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'democracy_club',
         'USER': 'postgres',
         'PASSWORD': '',

--- a/democracy_club/settings/zappa.py
+++ b/democracy_club/settings/zappa.py
@@ -12,9 +12,6 @@ ALLOWED_HOSTS = [
     'qwhhmkhcfk.execute-api.eu-west-1.amazonaws.com',  # Prod
 ]
 
-if os.environ.get('SERVERTYPE', None) == 'AWS Lambda':
-    GEOS_LIBRARY_PATH = '/var/task/libgeos_c.so'
-
 # Override the database name and user if needed
 DATABASES = {
     'default': {


### PR DESCRIPTION
* remove `django.contrib.gis` from `INSTALLED_APPS`
* monkey patch `S3Boto3Storage` to ensure `content_type` is `str()`
* clarify a couple of things in the docs