### PR TITLE
Remove django.contrib.gis/postgis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ democracy_club/static
 democracy_club/assets/uploads
 
 .cache
+.pytest_cache/
+

--- a/democracy_club/settings/base.py
+++ b/democracy_club/settings/base.py
@@ -19,7 +19,7 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'democracy_club',
         'USER': 'postgres',
         'PASSWORD': '',
@@ -86,7 +86,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
-    'django.contrib.gis',
     'localflavor',
     'markdown_deux',
     'django_extensions',


### PR DESCRIPTION
This was causing problems for me because Django 1.10 has an incompatibility with newer versions of `libgeos` which causes it to fall over trying to bootstrap the `contrib.gis` stuff. That is fixed in Django 1.11 so doesn't affect most of our projects. While working this out I realised that we're not actually using any GIS functionality in this project at all so we can just use `psycopg2` as our DB engine instead of `postgis` which simplifies things.