### PR TITLE
Job ads & new sub-nav on about section

### DIFF
--- a/democracy_club/templates/about/about_base.html
+++ b/democracy_club/templates/about/about_base.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="site-wrapper__body-text">
+  {% block page_heading %}{% endblock page_heading %}
+
+  <nav class="inline_page_nav">
+    <ul>
+      <li class="{% if request.path|slice:"-7:" == "/about/" %} nav-site__item--active{% endif %}"><a href="{% url "about" %}">About</a></li> ·
+      <li class="{% if request.path|slice:"-6:" == "/team/" %} nav-site__item--active{% endif %}"><a href="{% url "team" %}">The Team</a></li>
+    </ul>
+  </nav>
+
+  {% block main_content %}
+
+  {% endblock main_content %}
+
+
+</div>
+
+{% endblock %}

--- a/democracy_club/templates/about/about_base.html
+++ b/democracy_club/templates/about/about_base.html
@@ -6,7 +6,8 @@
   <nav class="inline_page_nav">
     <ul>
       <li class="{% if request.path|slice:"-7:" == "/about/" %} nav-site__item--active{% endif %}"><a href="{% url "about" %}">About</a></li> ·
-      <li class="{% if request.path|slice:"-6:" == "/team/" %} nav-site__item--active{% endif %}"><a href="{% url "team" %}">The Team</a></li>
+      <li class="{% if request.path|slice:"-6:" == "/team/" %} nav-site__item--active{% endif %}"><a href="{% url "team" %}">The Team</a></li> ·
+      <li class="{% if request.path|slice:"-6:" == "/jobs/" %} nav-site__item--active{% endif %}"><a href="{% url "jobs" %}">Jobs</a></li>
     </ul>
   </nav>
 

--- a/democracy_club/templates/about/index.html
+++ b/democracy_club/templates/about/index.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "about/about_base.html" %}
 {% load django_markdown %}
 
 {% block title %}About | {{ block.super }}{% endblock title %}
@@ -31,12 +31,11 @@ blockquote {
 </style>
 {% endblock %}
 
-{% block content %}
-<h1>About</h1>
+{% block page_heading %}<h1>About</h1>{% endblock page_heading %}
 
-<div class="fukol-grid">
+{% block main_content %}
 
-  <div class="fukol-grid__col fukol-grid__col--60-70">
+<article>
 
 {% filter markdown %}
 
@@ -124,39 +123,7 @@ Our data has reached over 12m people. Here’s what some of them say:
 - The Electoral Commission (2017) *[“Partnerships”](https://www.electoralcommission.org.uk/find-information-by-subject/electoral-registration/2017-uk-general-election-campaign/partnerships)*
 - TechPresident (2015) *[“Democracy Club Finally Lets Brits Know Who Is Running For Parliament”](http://techpresident.com/news/25519/democracy-club-brings-transparency-uks-obscure-election-procedures)*
 
-## Who we are
 
-We’re a 10,000 strong digital community who work online via Slack and Trello. Club members put in hundreds of hours of work to help build the databases that help inform voters. They sometimes get points for doing so: here's the [leaderboard](https://candidates.democracyclub.org.uk/leaderboard).
-
-The club is supported by a core team of three coordinators:
-
-![From left: Sym, Joe and Chris — Democracy Club coordinators](https://static.democracyclub.org.uk/media/hermes/heroes/now-we-are-three_hero.jpg "Sym, Joe and Chris")
-
-
-**Sym Roe ([@symroe](https://twitter.com/symroe))**
-
-Sym has 15 years experience in open data, government and technology, for folks like Government Digital Service, Ministry of Justice and FarmSubsidy.org. He has never knowingly set foot in a school. He lives in Stroud and has still not been a candidate on the Great British Bake Off.
-
-**Joe Mitchell ([@j0e_m](https://twitter.com/j0e_m))**
-
-Joe has a decade of experience in advocacy, communications and marketing, including with the UK Civil Service and United Nations. He went to many universities. He lives in Bristol, even though he is probably not cool enough to do so.
-
-**Chris Shaw**
-
-Chris has over 10 years of experience in software development and data wrangling in the research and education sectors. He studied Computer Science in Swansea, where he now lives. He started working on Democracy Club projects as a volunteer. We haven't worked out how to make him stop yet.
-
-The core team is overseen by an experienced board of directors:
-
-- Alice Casey
-- Alison Walters
-- Ian Watt
-- Mevan Babakar
-- Olly Benson
-- Rebecca Eligon
-- Rebecca Kemp
-- Sarah Hartley
-
-[Read about the board here.](https://democracyclub.org.uk/blog/2017/12/01/weve-got-board/)
 
 ## Who funds us
 
@@ -173,13 +140,5 @@ We also seek institutional funding. We're grateful to our existing and previous 
 
 {% endfilter %}
 
-  </div><!-- ./fukol-grid__col -->
-  <div class="fukol-grid__col fukol-grid__col--40-30">
-
-    {% include "_includes/form--donate-box.html" %}
-
-  </div><!-- /.fukol-grid__col -->
-</div><!-- /.fukol-grid -->
-
-
-{% endblock content %}
+</article>
+{% endblock main_content %}

--- a/democracy_club/templates/about/jobs.html
+++ b/democracy_club/templates/about/jobs.html
@@ -1,0 +1,213 @@
+{% extends "about/about_base.html" %}
+{% load markdown_deux_tags %}
+
+{% block page_heading %}<h1>Jobs</h1>{% endblock page_heading %}
+
+{% block main_content %}
+{% filter markdown %}
+We're currently hiring for 3 jobs:
+
+* [Elections assistant](#elections-assistant)
+* [Part-time assistant](#part-time-assistant)
+* [We're always interested in new people](#always-be-hiring)
+
+{% endfilter %}
+
+
+
+
+<article id="election-assistant">
+
+
+{% filter markdown %}
+<script type='application/ld+json'>
+{
+    "@context": "http://schema.org/",
+    "@type": "JobPosting",
+    "validThrough": "2018-12-10",
+    "estimatedSalary": "~£20k (pro rata)",
+    "datePosted": "2018-10-22",
+    "employmentType": "Part time",
+    "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Democracy Club Community Interest Company"
+    },
+    "jobLocation": {
+        "@type": "Place",
+        "address": "UK Wide"
+    },
+    "title": "Part-time assistant, Democracy Club",
+    "description": "Democracy Club is made up of lots of people doing things to make democracy work better. Many of these people give their time voluntarily, because they love democracy. Hurray!   We also have a small staff team. And they could do with some support. For example, with help to:  Organise public events Read, summarise and share relevant reports that might affect us Make sure our finances are in order (it’s fairly straightforward, honest) Contact potential partners, set up calls and meetings Ensure that Trello (our shared to-do list) is orderly and readable Manage our shared inbox Monitor edits to our databases and help out new volunteers Ensure minutes and agendas are sorted for board meetings Help tell our story on social media  And generally helping out wherever is most useful at the time.  You’ll be a well-organised, helpful person with good communication skills and some experience in doing the types of things listed above."
+}
+</script>
+
+## Elections assistant
+
+This is a short-term contract for someone who can help us make a giant leap in voter information for the local elections next May.
+
+### What’s happening next year?
+
+We’re hoping to boost informed turnout at the local elections on 2 May 2019. Around 30 million people will have the chance to vote.
+
+We hope that our polling location data and finder (Where Do I Vote?) will cover all councils and that we’ll have useful information on every candidate (Who Can I Vote For?).
+
+### What will you do?
+
+* Help us partner with every local authority with elections next May to publish polling location data, including dealing with queries; tracking progress towards completion; and managing the workflow for dealing with errors reported by the public on the day
+* Help us partner with more data re-users: pitch to local journalists and newspapers, campaigns and community organisations
+* Get more and better data on candidates: work with parties, agents, candidates and our incredible network of volunteers
+* Manage an open hustings database, with the possibility of running Democracy Club hustings too
+* Help manage our team inbox and social media
+* Help maintain our Trello boards
+* Do some basic press and PR for Democracy Club
+* ...and anything else you can convince us that you should work on :)
+
+### What skills, experience and behaviours do you need?
+
+* Polite, curious, critical thinker
+* Good written communication skills
+* Passionate about digital and democracy and the space where they meet
+* Great social skills and the ability to work with people of high technical knowledge and none
+* Organised — there will be lots of things happening at once
+* Non-partisan (you should not be actively involved in any political party)
+
+### Also, if you have any skills as a …
+
+* Researcher / anthropologist
+* Designer
+* Coder
+
+...that would be exciting.
+
+### What we can offer:
+
+* A chance to immerse yourself in civic technology, get up-to-speed in tech for good and digital, and to help save democracy.
+* £10/hr
+* Laptop supplied
+* Exclusive Democracy Club stickers!
+
+### I love democracy, this looks brilliant, how do I apply?
+
+[Please fill in this Google form](#).
+
+
+
+{% endfilter %}
+</article>
+<hr>
+<article id="part-time-assistant">
+
+
+{% filter markdown %}
+<script type='application/ld+json'>
+{
+    "@context": "http://schema.org/",
+    "@type": "JobPosting",
+    "validThrough": "2018-12-10",
+    "estimatedSalary": "~£20k (pro rata)",
+    "datePosted": "2018-10-22",
+    "employmentType": "Part time",
+    "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Democracy Club Community Interest Company"
+    },
+    "jobLocation": {
+        "@type": "Place",
+        "address": "UK Wide"
+    },
+    "title": "Part-time assistant, Democracy Club",
+    "description": "Democracy Club is made up of lots of people doing things to make democracy work better. Many of these people give their time voluntarily, because they love democracy. Hurray!   We also have a small staff team. And they could do with some support. For example, with help to:  Organise public events Read, summarise and share relevant reports that might affect us Make sure our finances are in order (it’s fairly straightforward, honest) Contact potential partners, set up calls and meetings Ensure that Trello (our shared to-do list) is orderly and readable Manage our shared inbox Monitor edits to our databases and help out new volunteers Ensure minutes and agendas are sorted for board meetings Help tell our story on social media  And generally helping out wherever is most useful at the time.  You’ll be a well-organised, helpful person with good communication skills and some experience in doing the types of things listed above."
+}
+</script>
+
+## Part-time assistant, Democracy Club
+
+Democracy Club is made up of lots of people doing things to make democracy work better. Many of these people give their time voluntarily, because they love democracy. Hurray!
+
+We also have a small staff team. And they could do with some support. For example, with help to:
+
+* Organise public events
+* Read, summarise and share relevant reports that might affect us
+* Make sure our finances are in order (it’s fairly straightforward, honest)
+* Contact potential partners, set up calls and meetings
+* Ensure that Trello (our shared to-do list) is orderly and readable
+* Manage our shared inbox
+* Monitor edits to our databases and help out new volunteers
+* Ensure minutes and agendas are sorted for board meetings
+* Help tell our story on social media
+
+And generally helping out wherever is most useful at the time.
+
+You’ll be a well-organised, helpful person with good communication skills and some experience in doing the types of things listed above.
+
+
+#### Location
+Anywhere in the UK (so long as it has speedy internet). Possible bonus points for those based in Bristol. Occasional travel required.
+
+#### Money
+~£20k (pro rata)
+
+#### Hours
+Our ideal would probably be a few hours each working day, but we’re flexible!
+
+Interested? <a href="https://docs.google.com/forms/d/1pC9Ur_0U5Ji3l_rYhvU5xEuYZs_6-eu2e7EybJPlNAI/prefill">
+  Fill in this simple form to begin</a>; provide examples where you can.
+
+Know someone who might be interested? Please forward this on!
+
+{% endfilter %}
+</article>
+<hr>
+<article id="always-be-hiring">
+<script type='application/ld+json'>
+{
+	"@context": "http://schema.org/",
+	"@type": "JobPosting",
+	"estimatedSalary": "£20-40k (depending on skills)",
+	"datePosted": "2018-10-22",
+	"employmentType": "Flexable",
+    "validThrough": "2020-12-10",
+	"hiringOrganization": {
+		"@type": "Organization",
+		"name": "Democracy Club Community Interest Company"
+	},
+	"jobLocation": {
+		"@type": "Place",
+		"address": "UK Wide"
+	},
+	"title": "Are you interested in working at Democracy Club?",
+	"description": "Democracy Club is made up of lots of people doing things to make democracy work better. Many of these people give their time voluntarily, because they love democracy. Hurray!   We also have a small staff team. And they could do with some support. We are actively looking for the kinds of people below. However, if you think that you could bring valuable skills to the team that we’ve not listed, and you want to help make democracy better, get in touch anyway.  Python or frontend developers, Designers, User researchers, Community organisers, Fundraisers, Evaluation people, General mucker-inners (events, admin, finance, comms)"
+}
+</script>
+{% filter markdown %}
+
+
+## We’re hiring!
+
+Democracy Club is made up of lots of people doing things to make democracy work better. Many of these people give their time voluntarily, because they love democracy. Hurray!
+
+We also have a small staff team. We plan to raise money to increase the team’s numbers in order to better support existing volunteers, galvanise new volunteers and serve millions more citizens.
+
+We are actively looking for the kinds of people below. However, if you think that you could bring valuable skills to the team that we’ve not listed, and you want to help make democracy better, get in touch anyway.
+
+* Python or frontend developers
+* Designers
+* User researchers
+* Community organisers
+* Fundraisers
+* Evaluation people
+* General mucker-inners (events, admin, finance, comms)
+
+#### Location
+Anywhere in the UK (so long as it has speedy internet) — possible bonus points for those based in Bristol
+
+#### Money
+We’re a largely grant-funded non-profit, but we’ll see what we can do
+
+#### Hours
+We’re flexible!
+
+Interested? Fill in this simple form for starters.
+{% endfilter %}
+</article>
+{% endblock main_content %}

--- a/democracy_club/templates/about/team.html
+++ b/democracy_club/templates/about/team.html
@@ -1,0 +1,43 @@
+{% extends "about/about_base.html" %}
+{% load markdown_deux_tags %}
+
+
+{% block page_heading %}<h1>The Team</h1>{% endblock page_heading %}
+
+{% block main_content %}
+{% filter markdown %}
+
+We’re a 10,000 strong digital community who work online via Slack and Trello. Club members put in hundreds of hours of work to help build the databases that help inform voters. They sometimes get points for doing so: here's the [leaderboard](https://candidates.democracyclub.org.uk/leaderboard).
+
+The club is supported by a core team of three coordinators:
+
+![From left: Sym, Joe and Chris — Democracy Club coordinators](https://static.democracyclub.org.uk/media/hermes/heroes/now-we-are-three_hero.jpg "Sym, Joe and Chris")
+
+
+**Sym Roe ([@symroe](https://twitter.com/symroe))**
+
+Sym has 15 years experience in open data, government and technology, for folks like Government Digital Service, Ministry of Justice and FarmSubsidy.org. He has never knowingly set foot in a school. He lives in Stroud and has still not been a candidate on the Great British Bake Off.
+
+**Joe Mitchell ([@j0e_m](https://twitter.com/j0e_m))**
+
+Joe has a decade of experience in advocacy, communications and marketing, including with the UK Civil Service and United Nations. He went to many universities. He lives in Bristol, even though he is probably not cool enough to do so.
+
+**Chris Shaw**
+
+Chris has over 10 years of experience in software development and data wrangling in the research and education sectors. He studied Computer Science in Swansea, where he now lives. He started working on Democracy Club projects as a volunteer. We haven't worked out how to make him stop yet.
+
+The core team is overseen by an experienced board of directors:
+
+- Alice Casey
+- Alison Walters
+- Ian Watt
+- Mevan Babakar
+- Olly Benson
+- Rebecca Eligon
+- Rebecca Kemp
+- Sarah Hartley
+
+[Read about the board here.](https://democracyclub.org.uk/blog/2017/12/01/weve-got-board/)
+
+{% endfilter %}
+{% endblock %}

--- a/democracy_club/templates/base.html
+++ b/democracy_club/templates/base.html
@@ -13,7 +13,7 @@
         <nav class="nav-site-wrap">
           <ul class="nav-site js-nav-site">
             <li class="nav-site__item nav-site__item--home{% if request.path == "/" %} nav-site__item--active{% endif %}"><a href="/">Home</a></li>
-            <li class="nav-site__item{% if request.path == "/about/" %} nav-site__item--active{% endif %}"><a href="/about/">About</a></li>
+            <li class="nav-site__item{% if request.path|slice:"7" == "/about/" %} nav-site__item--active{% endif %}"><a href="/about/">About</a></li>
             <li class="nav-site__item{% if request.path|slice:":10" == "/projects/" %} nav-site__item--active{% endif %}"><a href="/projects/">Projects</a></li>
             <li class="nav-site__item{% if request.path == "/quests/" %} nav-site__item--active{% endif %}"><a href="/quests/">Quests</a></li>
             <li class="nav-site__item{% if request.path == "/blog/" %} nav-site__item--active{% endif %}"><a href="/blog/">Blog</a></li>

--- a/democracy_club/templates/base.html
+++ b/democracy_club/templates/base.html
@@ -16,7 +16,7 @@
             <li class="nav-site__item{% if request.path|slice:"7" == "/about/" %} nav-site__item--active{% endif %}"><a href="/about/">About</a></li>
             <li class="nav-site__item{% if request.path|slice:":10" == "/projects/" %} nav-site__item--active{% endif %}"><a href="/projects/">Projects</a></li>
             <li class="nav-site__item{% if request.path == "/quests/" %} nav-site__item--active{% endif %}"><a href="/quests/">Quests</a></li>
-            <li class="nav-site__item{% if request.path == "/blog/" %} nav-site__item--active{% endif %}"><a href="/blog/">Blog</a></li>
+            <li class="nav-site__item{% if request.path|slice:"6" == "/blog/" %} nav-site__item--active{% endif %}"><a href="/blog/">Blog</a></li>
             <li class="nav-site__item{% if request.path == "/contact/" %} nav-site__item--active{% endif %}"><a href="/contact/">Contact</a></li>
             <li class="nav-site__item{% if request.path == "/donate/" %} nav-site__item--active{% endif %}"><a href="/donate/?utm_source=menu">Donate</a></li>
           </ul>

--- a/democracy_club/urls.py
+++ b/democracy_club/urls.py
@@ -28,9 +28,12 @@ urlpatterns = [
     url(r'^thanks/finished$',
         TemplateView.as_view(template_name="thanks_finished.html")),
 
+
     # About URLs
     url(r'^about/$',
         TemplateView.as_view(template_name="about/index.html"), name="about"),
+    url(r'^about/jobs/$',
+        TemplateView.as_view(template_name="about/jobs.html"), name="jobs"),
     url(r'^about/team/$',
         TemplateView.as_view(template_name="about/team.html"), name="team"),
 

--- a/democracy_club/urls.py
+++ b/democracy_club/urls.py
@@ -27,8 +27,14 @@ urlpatterns = [
         TemplateView.as_view(template_name="thanks.html")),
     url(r'^thanks/finished$',
         TemplateView.as_view(template_name="thanks_finished.html")),
+
+    # About URLs
     url(r'^about/$',
-        TemplateView.as_view(template_name="about.html"), name="about"),
+        TemplateView.as_view(template_name="about/index.html"), name="about"),
+    url(r'^about/team/$',
+        TemplateView.as_view(template_name="about/team.html"), name="team"),
+
+
     url(r'^privacy/$',
         TemplateView.as_view(template_name="privacy.html"), name="privacy"),
     url(r'^code-of-conduct/$',


### PR DESCRIPTION
This might be the best way to explain the changes:

![screenshot 2018-10-22 15 02 45](https://user-images.githubusercontent.com/242329/47296986-cac9b080-d60b-11e8-9169-c1d704aaead7.png)

![screenshot 2018-10-22 15 02 50](https://user-images.githubusercontent.com/242329/47296987-cc937400-d60b-11e8-96cc-b8d0f94c0f51.png)

![screenshot 2018-10-22 15 02 55](https://user-images.githubusercontent.com/242329/47296994-d026fb00-d60b-11e8-91c7-ecf34297bbbf.png)

As for the text of the job ads, see https://github.com/DemocracyClub/Website/commit/0905350b60b89921fb3437f19a6dc6cfef96ac4b. I can do a staging deploy if it would help?