### PR TITLE
Updating the 'Who funds us' bit

### DIFF
--- a/democracy_club/templates/about/index.html
+++ b/democracy_club/templates/about/index.html
@@ -133,14 +133,7 @@ Our data has reached over 12m people. Here’s what some of them say:
 
 Ideally, you do. [Chip in £3/month here](https://democracyclub.org.uk/donate/). Your donations will mean we can do this work openly, for everybody.
 
-We also seek institutional funding. We're grateful to our existing and previous funders:
-
-- Unbound Philanthropy
-- The Electoral Commission
-- The Welsh Government
-- Joseph Rowntree Trust
-- Google.org
-
+We also seek funds via grants and sales. You can see [our funding policy and history here](https://democracyclub.org.uk/about/funding/). 
 
 {% endfilter %}
 


### PR DESCRIPTION
Removed the bullet point funders and linked to the full funding page instead.