### PR TITLE
Various django compatibility fixes

### DIFF
--- a/democracy_club/apps/dc_members/migrations/0001_initial.py
+++ b/democracy_club/apps/dc_members/migrations/0001_initial.py
@@ -25,8 +25,14 @@ class Migration(migrations.Migration):
                 ('postcode', models.CharField(max_length=20, blank=True)),
                 ('token', models.CharField(
                     db_index=True, max_length=255, blank=True)),
-                ('user', models.ForeignKey(
-                    to=settings.AUTH_USER_MODEL, unique=True)),
+                (
+                    'user',
+                    models.ForeignKey(
+                        to=settings.AUTH_USER_MODEL,
+                        unique=True,
+                        on_delete=models.CASCADE,
+                    )
+                ),
             ],
             options={
             },

--- a/democracy_club/apps/dc_members/migrations/0005_auto_20150430_1903.py
+++ b/democracy_club/apps/dc_members/migrations/0005_auto_20150430_1903.py
@@ -15,7 +15,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='member',
             name='user',
-            field=models.ForeignKey(null=True, to=settings.AUTH_USER_MODEL, unique=True),
+            field=models.ForeignKey(
+                null=True,
+                to=settings.AUTH_USER_MODEL,
+                unique=True,
+                on_delete=models.CASCADE,
+            ),
             preserve_default=True,
         ),
     ]

--- a/democracy_club/apps/dc_members/migrations/0007_auto_20160124_1515.py
+++ b/democracy_club/apps/dc_members/migrations/0007_auto_20160124_1515.py
@@ -15,6 +15,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='member',
             name='user',
-            field=models.OneToOneField(null=True, to=settings.AUTH_USER_MODEL),
+            field=models.OneToOneField(
+                null=True,
+                to=settings.AUTH_USER_MODEL,
+                on_delete=models.CASCADE,
+            ),
         ),
     ]

--- a/democracy_club/apps/dc_members/models.py
+++ b/democracy_club/apps/dc_members/models.py
@@ -5,6 +5,7 @@ from jsonfield import JSONField
 
 from django.db import models
 from django.contrib.auth.models import User
+from django.urls import reverse
 
 class Member(models.Model):
     """
@@ -21,9 +22,8 @@ class Member(models.Model):
     source = models.CharField(blank=True, max_length=800)
 
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('view_member', (), {})
+        return reverse('view_member')
 
     def generate_token(self):
         joiner = "--".encode('utf8')

--- a/democracy_club/apps/dc_members/models.py
+++ b/democracy_club/apps/dc_members/models.py
@@ -12,7 +12,7 @@ class Member(models.Model):
     Members are people who have done tasks in the past.  They are added when
     someone gives us their information with the intent of "joining" DC.
     """
-    user = models.OneToOneField(User, null=True)
+    user = models.OneToOneField(User, null=True, on_delete=models.CASCADE)
     name = models.CharField(blank=True, max_length=255)
     email = models.EmailField()
     constituency = models.CharField(blank=True, max_length=255)

--- a/democracy_club/apps/dc_members/views.py
+++ b/democracy_club/apps/dc_members/views.py
@@ -1,7 +1,7 @@
 from django.views.generic.edit import UpdateView
 from django.views.generic import DetailView, RedirectView
 from django.contrib.auth import login, authenticate
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.http import is_safe_url
 
 from ratelimit.mixins import RatelimitMixin

--- a/democracy_club/apps/donations/views.py
+++ b/democracy_club/apps/donations/views.py
@@ -1,5 +1,5 @@
 from django.views.generic import TemplateView, RedirectView
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .helpers import GoCardlessHelper
 

--- a/democracy_club/apps/projects/urls.py
+++ b/democracy_club/apps/projects/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.views.generic import RedirectView, TemplateView
 
 urlpatterns = [

--- a/democracy_club/apps/results/models.py
+++ b/democracy_club/apps/results/models.py
@@ -5,7 +5,7 @@ from django_extensions.db.models import TimeStampedModel
 from everyelection.models import AuthorityElection
 
 class ElectionResultSet(TimeStampedModel):
-    election = models.ForeignKey(AuthorityElection)
+    election = models.ForeignKey(AuthorityElection, on_delete=models.CASCADE)
     reported_turnout = models.IntegerField(blank=True, null=True)
     calculated_turnout = models.IntegerField(blank=True, null=True)
 

--- a/democracy_club/urls.py
+++ b/democracy_club/urls.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.conf.urls.static import static
 from django.views.generic import TemplateView, RedirectView
 from django.contrib.auth import views as auth_views

--- a/democracy_club/urls.py
+++ b/democracy_club/urls.py
@@ -18,7 +18,7 @@ handler500 = 'dc_theme.urls.dc_server_error'
 
 urlpatterns = [
     # Uncomment the next line to enable the admin:
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include('allauth.urls')),
     url(r'^logout/$', auth_views.logout,
         {'next_page': '/'}, name='auth_logout'),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 # to each package in each requirements/*.txt.
 
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.0.0
--e git+https://github.com/DemocracyClub/dc_base_theme.git@0.3.7#egg=dc_base_theme
+-e git+https://github.com/DemocracyClub/dc_base_theme.git@0.3.9#egg=dc_base_theme
 -e git+https://github.com/DemocracyClub/django-hermes.git#egg=hermes
 -e git+https://github.com/klen/django_markdown.git#egg=django_markdown
 git+https://github.com/chrisdrackett/django-typogrify.git


### PR DESCRIPTION
This PR doesn't upgrade django and definitely doesn't fix _all_ of the django compatibility issues we need to deal with, but it does make some easy updates we will need to make in future (e.g: removing/updating various things which are deprecated or removed in future versions) in a backwards-compatible way.
As such we can merge this now, it won't break anything while we're still on 1.10 and its some work that we don't need to do later.