### PR TITLE
update widget embed code with translations support/customiser

### DIFF
--- a/democracy_club/apps/projects/templates/projects/polling-stations/embed_code.html
+++ b/democracy_club/apps/projects/templates/projects/polling-stations/embed_code.html
@@ -10,17 +10,46 @@
 {% filter markdown %}
 
 
-### Example widget
+We'd love you to use our polling station finder on your web site. If you do, we kindly ask that you:
+
+1. Credit Democracy Club, linking to our home page at [https://democracyclub.org.uk/](https://democracyclub.org.uk/) along side the embedded widget.
+2. <a href="{% url "contact" %}">Let us know</a> you're using it. We don't limit use, but it's great to know who has used the embed feature.
+3. Give us feedback either from your users or yourselves. We want to learn and iterate, and we can't do that without feedback!
+
+<h2>Customise and Embed</h2>
+For councils in Wales, we offer optional Welsh language support.
+<form id="widget-options" class="form form-inline">
+    <div class="form-group">
+      <fieldset>
+        <label for="no-lang" class="block-label selection-button-radio">
+          <input type="radio" name="language" id="no-lang" value="no-lang" checked="checked">
+          In English only
+        </label>
+        <label for="en" class="block-label selection-button-radio">
+          <input type="radio" name="language" id="en" value="en">
+          With language toggle (Default English)
+        </label>
+        <label for="cy" class="block-label selection-button-radio">
+          <input type="radio" name="language" id="cy" value="cy">
+          With language toggle (Default Welsh)
+        </label>
+      </fieldset>
+    </div>
+    <button>Generate</button>
+</form>
+
 <figure>
   <noscript>
     <iframe src="https://wheredoivote.co.uk/embed/"
       style="width:100%; height:1100px" frameborder="0" scrolling="no">
     </iframe>
   </noscript>
-  <div id="dc_wdiv" aria-live="polite" role="region"></div>
-  <script type="text/javascript"
-    src="https://widget.wheredoivote.co.uk/wdiv.js">
-  </script>
+  <div id="widget-area">
+    <div id="dc_wdiv" aria-live="polite" role="region"></div>
+    <script type="text/javascript"
+      src="https://widget.wheredoivote.co.uk/wdiv.js">
+    </script>
+  </div>
   <figcaption>
     Live data varies, so results might not show for example postcodes.
     We tend not to have data outside of major elections, <a href="{% url "contact" %}">contact us</a>
@@ -28,25 +57,23 @@
   </figcaption>
 </figure>
 
-We'd love you to use our polling station finder on your web site. If you do, we kindly ask that you:
+To embed on your site, use the following code:
+{% endfilter %}
 
-1. Credit Democracy Club, linking to our home page at [https://democracyclub.org.uk/](https://democracyclub.org.uk/) along side the embedded widget.
-2. <a href="{% url "contact" %}">Let us know</a> you're using it. We don't limit use, but it's great to know who has used the embed feature.
-3. Give us feedback either from your users or yourselves. We want to learn and iterate, and we can't do that without feedback!
+<div id="code-area">
+<pre><code>&lt;noscript&gt;
+  &lt;iframe src="https://wheredoivote.co.uk/embed/"
+    style="width:100%; height:1100px" frameborder="0" scrolling="no"&gt;
+  &lt;/iframe&gt;
+&lt;/noscript&gt;
+&lt;div id="dc_wdiv" aria-live="polite" role="region"&gt;&lt;/div&gt;
+&lt;script type="text/javascript"
+  src="https://widget.wheredoivote.co.uk/wdiv.js"&gt;
+&lt;/script&gt;
+</code></pre>
+</div>
 
-To embed the site, use the following code:
-
-
-    <noscript>
-      <iframe src="https://wheredoivote.co.uk/embed/"
-        style="width:100%; height:1100px" frameborder="0" scrolling="no">
-      </iframe>
-    </noscript>
-    <div id="dc_wdiv" aria-live="polite" role="region"></div>
-    <script type="text/javascript"
-      src="https://widget.wheredoivote.co.uk/wdiv.js">
-    </script>
-
+{% filter markdown %}
 ## Adding your data
 Work in a council and want your polling stations to work in the widget?
 See our <a href="{% url 'projects:polling_data_upload' %}">plans page</a> for more info.
@@ -61,5 +88,68 @@ your bespoke applications.
 Please [contact us]({% url "contact"%}) for more information about this.
 
 {% endfilter %}
+
+<script>
+  var form = document.querySelector('#widget-options');
+  if (form) {
+    form.addEventListener('submit', handleWidgetOptions);
+  }
+
+  function handleWidgetOptions(event) {
+    event.preventDefault();
+    createWidgetVersion(form.elements.language.value);
+  }
+
+  function getEmbedCode(customAttributes) {
+    return '<pre><code>&lt;noscript&gt;\n' +
+      '  &lt;iframe src="https://wheredoivote.co.uk/embed/"\n' +
+      '    style="width:100%; height:1100px" frameborder="0" scrolling="no"&gt;\n' +
+      '  &lt;/iframe&gt;\n' +
+      '&lt;/noscript&gt;\n' +
+      '&lt;div id="dc_wdiv" '+ customAttributes + '&gt;&lt;/div&gt;\n' +
+      '&lt;script type="text/javascript"\n' +
+      '  src="https://widget.wheredoivote.co.uk/wdiv.js"&gt;\n' +
+      '&lt;/script&gt;\n' +
+      '</code></pre>\n';
+  }
+
+  function makeAttributeList(language) {
+    var attrs = '';
+    if ((language === 'en') || (language === 'cy')) {
+      attrs = 'data-language="' + language + '" ';
+    }
+    return attrs + 'aria-live="polite" role="region"';
+  }
+
+  function makeWidget(language) {
+    var div = document.createElement('div');
+    div.setAttribute('id', 'dc_wdiv');
+    if ((language === 'en') || (language === 'cy')) {
+      div.setAttribute('data-language', language);
+    }
+    div.setAttribute('aria-live', 'polite');
+    div.setAttribute('role', 'region');
+    return div;
+  }
+
+  function makeScript() {
+    var script = document.createElement('script');
+    script.type = "text/javascript";
+    script.src = "https://widget.wheredoivote.co.uk/wdiv.js";
+    return script;
+  }
+
+  function createWidgetVersion(language) {
+    var widgetArea = document.querySelector('#widget-area');
+    var codeArea = document.querySelector('#code-area');
+    var widget = makeWidget(language);
+    var script = makeScript();
+    var embedCode = getEmbedCode(makeAttributeList(language));
+    widgetArea.innerHTML = '';
+    widgetArea.appendChild(widget);
+    widgetArea.appendChild(script);
+    codeArea.innerHTML = embedCode;
+  }
+</script>
 {% endblock main_content %}
 


### PR DESCRIPTION
This PR roughly nicks the code Ali put together in https://github.com/DemocracyClub/WhereDoIVote-Widget/pull/289 , backports it to ES5 syntax for compatibility and shoves it into the existing `polling-stations/embed` template. This is imperfect, but I think it'll do for now.

I reckon in general, this whole page/content will need review ahead of next year's May elections anyway especially as we will have added the option to show candidate data by that point. That will add additional configuration, but we might also want to rebrand it as a Democracy Club widget instead of a WhereDoIVote widget. Maybe it wants different presentation for councils vs media orgs etc etc
