### PR TITLE
Hotfix/scale images

### DIFF
--- a/democracy_club/apps/projects/templates/projects/polling-stations/upload_data.html
+++ b/democracy_club/apps/projects/templates/projects/polling-stations/upload_data.html
@@ -83,19 +83,15 @@ your website, free of charge.
 
 You'll need to add a bit of code to your site.
 [Find out how]({% url "projects:polling_embed_code" %}).
+{% endfilter markdown %}
 
-<div class="ds-grid" style="--gridCellMin: 15ch; --gridGap: 1rem;">
-<ul>
-    <li>
+    <div class="partner-logo">
         <a href="https://www.digitalmarketplace.service.gov.uk/g-cloud/services/505951175500567">
-            <img src="{% static 'ccs-certificate.png' %}" alt="">
+            <img style="flex-basis:auto; padding: 1rem; "  src="{% static 'ccs-certificate.png' %}" alt="Crown Commercial Service Supplier">
         </a>
-    </li>
-    <li>
-        <img src="{% static 'images/reusers/logo--the-electoral-commission.jpg' %}" alt="">
-    </li>
-</ul>
-</div>
+        <img style="max-width: 300px; padding: 1rem; " src="{% static 'images/reusers/logo--the-electoral-commission.jpg' %}" alt="The Electoral Commission">
+    </div>
+{% filter markdown %}
 
 *Want to talk to a human? Please email [pollingstations@democracyclub.org.uk](mailto:pollingstations@democracyclub.org.uk) or call on [03331 122450](tel:443331122450)*
 

--- a/democracy_club/assets/scss/styles.scss
+++ b/democracy_club/assets/scss/styles.scss
@@ -137,3 +137,10 @@ figure {
   }
   #toc, nav, footer {display: none}
 }
+
+.partner-logo {
+  display:flex;
+  flex-wrap: wrap; 
+  justify-content: space-evenly; 
+  align-items: baseline;
+}


### PR DESCRIPTION
This work ends markdown filters where html is required to style logos side by side. It makes the images equal size and responsive. 
<img width="369" alt="Screen Shot 2021-08-25 at 9 58 04 AM" src="https://user-images.githubusercontent.com/7017118/130761217-4ae6cbd8-cbbb-4013-92b8-a52ed233e181.png">
<img width="923" alt="Screen Shot 2021-08-25 at 10 00 24 AM" src="https://user-images.githubusercontent.com/7017118/130761745-bd8ee6b0-99df-4253-b403-0a8068957a98.png">



