### PR TITLE
Hotfix/error pages

### DIFF
--- a/democracy_club/templates/404.html
+++ b/democracy_club/templates/404.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block title %}Page Not found{% endblock %}
-
-{% block page_content %}
-<p>This is not the page you were looking for.</p>
-{% endblock %}

--- a/democracy_club/templates/500.html
+++ b/democracy_club/templates/500.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block title %}Server Error{% endblock %}
-
-{% block page_content %}
-<h1>Whoops!</h1>
-{% endblock %}


### PR DESCRIPTION
This work removes removes local error pages that were conflicting with error pages provided by `dc_utils`. 

Before

![Screen Shot 2021-10-14 at 9 52 47 AM](https://user-images.githubusercontent.com/7017118/137284547-d1722b46-f958-4d88-8017-df4719742763.png)

After
![Screen Shot 2021-10-14 at 9 52 33 AM](https://user-images.githubusercontent.com/7017118/137284566-96f39339-a894-43b2-9211-8a7af1a0126c.png)


