### PR TITLE
Correct HTML Title tags everywhere

### DIFF
--- a/democracy_club/apps/core/report_helpers/views.py
+++ b/democracy_club/apps/core/report_helpers/views.py
@@ -22,4 +22,5 @@ class MarkdownFileView(TemplateView):
         html = md.convert(rendered_template)
         context["html_content"] = html
         context["toc"] = md.toc
+        context["page_title"] = md.toc_tokens[0]["name"]
         return context

--- a/democracy_club/apps/core/tests/test_html.py
+++ b/democracy_club/apps/core/tests/test_html.py
@@ -43,6 +43,7 @@ class TestHtml:
             reverse(
                 "wheredoivote_user_feedback:wheredoivote_user_feedback_2018"
             ),
+            reverse("projects:every_election"),
         ]
 
     @pytest.mark.django_db
@@ -52,3 +53,25 @@ class TestHtml:
                 assert client.get(url).status_code == 200
                 _, errors = validate_html(client, url)
                 assert errors == ""
+
+    @pytest.mark.django_db
+    def test_page_title(self, client, urls):
+        """test every page has a page title in the
+        block title tag"""
+        for url in urls:
+            response = client.get(url)
+            assert "<title>" in response.content.decode("utf-8")
+            assert "</title>" in response.content.decode("utf-8")
+
+    def test_report_page_title(self, client):
+        """test report page has a page title in the
+        block title tag that is equal to the report title"""
+        response = client.get("/report_2016/")
+        assert (
+            "<title>Towards better elections | Democracy Club</title>"
+            in response.content.decode("utf-8")
+        )
+        assert (
+            "<title> | Democracy Club</title>"
+            not in response.content.decode("utf-8")
+        )

--- a/democracy_club/apps/projects/templates/projects/candidates.html
+++ b/democracy_club/apps/projects/templates/projects/candidates.html
@@ -3,9 +3,7 @@
 {% load static %}
 {# fmt:off #}
 
-{% block title %}
-Candidates Wiki
-{% endblock %}
+{% block title %}Candidates Wiki{% endblock title %}
 
 {% block content %}
 <div class="ds-stack-smaller">

--- a/democracy_club/apps/projects/templates/projects/cvs.html
+++ b/democracy_club/apps/projects/templates/projects/cvs.html
@@ -2,10 +2,7 @@
 {% load markdown_filter %}
 {# fmt:off #}
 
-{% block title %}
-Democracy Club CVs
-{% endblock %}
-
+{% block title %}Democracy Club CVs{% endblock title %}
 
 {% block content %}
 <div class="ds-stack-smaller">

--- a/democracy_club/apps/projects/templates/projects/data.html
+++ b/democracy_club/apps/projects/templates/projects/data.html
@@ -3,9 +3,8 @@
 {%  load static %}
 {# fmt:off #}
 
-{% block title %}
-Data and APIs
-{% endblock %}
+{% block title %}Data and APIs{% endblock title %}
+
 
 {% block content %}
 <div class="ds-stack-smaller">

--- a/democracy_club/apps/projects/templates/projects/election-widget.html
+++ b/democracy_club/apps/projects/templates/projects/election-widget.html
@@ -1,7 +1,6 @@
 {% extends "projects/projects_base.html" %}
-{% block title %}
-  Election widget
-{% endblock %}
+{% block title %}Election widget{% endblock title %}
+
 
 {% block content %}
   <div class="ds-stack-smaller">

--- a/democracy_club/apps/projects/templates/projects/electionleaflets.html
+++ b/democracy_club/apps/projects/templates/projects/electionleaflets.html
@@ -3,9 +3,7 @@
 {% load static %}
 {# fmt:off #}
 
-{% block title %}
-Election Leaflets
-{% endblock %}
+{% block title %}Election Leaflets{% endblock title %}
 
 {% block content %}
 <div class="ds-stack-smaller">

--- a/democracy_club/apps/projects/templates/projects/every_election.html
+++ b/democracy_club/apps/projects/templates/projects/every_election.html
@@ -1,5 +1,6 @@
 {% extends "projects/projects_base.html" %}
 {% load static %}
+{% block title %}EveryElection{% endblock title %}
 
 {% block content %}
   <h1>EveryElection</h1>

--- a/democracy_club/apps/projects/templates/projects/past.html
+++ b/democracy_club/apps/projects/templates/projects/past.html
@@ -1,6 +1,7 @@
 {% extends "projects/projects_base.html" %}
 {% load markdown_filter %}
 {# fmt:off #}
+{% block title %}Past Projects{% endblock title %}
 {% block page_heading %}
     <h1>Past projects</h1>
 {% endblock %}

--- a/democracy_club/apps/projects/templates/projects/polling-stations/embed_code.html
+++ b/democracy_club/apps/projects/templates/projects/polling-stations/embed_code.html
@@ -1,6 +1,7 @@
 {% extends "projects/polling-stations/polling_stations_base.html" %}
 {% load markdown_filter %}
 {# fmt:off #}
+{% block title %}Polling Station finder{% endblock title %}
 
 {% block page_title %}
     <h1>Polling station finder</h1>

--- a/democracy_club/apps/projects/templates/projects/polling-stations/polling_stations_base.html
+++ b/democracy_club/apps/projects/templates/projects/polling-stations/polling_stations_base.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load markdown_filter %}
+{% block title %}Polling station finder{% endblock title %}
 
 {% block content %}
     <div class="ds-stack-smaller">
@@ -16,7 +17,6 @@
                 </li>
             </ul>
         </nav>
-        {% block page_title %}{% endblock page_title %}
 
         {% block main_content %}
         {% endblock main_content %}

--- a/democracy_club/apps/projects/templates/projects/projects_home.html
+++ b/democracy_club/apps/projects/templates/projects/projects_home.html
@@ -1,5 +1,5 @@
 {% extends "projects/projects_base.html" %}
-
+{% block title %}Projects{% endblock title %}
 {% block page_heading %}
     <h1>Projects</h1>
 {% endblock %}

--- a/democracy_club/apps/projects/templates/projects/reports_home.html
+++ b/democracy_club/apps/projects/templates/projects/reports_home.html
@@ -1,6 +1,6 @@
 {% extends "projects/projects_base.html" %}
 {% load static %}
-
+{% block title %}Reports{% endblock title %}
 {% block page_heading %}
     <h1>Reports</h1>
 {% endblock %}

--- a/democracy_club/apps/projects/templates/projects/representatives.html
+++ b/democracy_club/apps/projects/templates/projects/representatives.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load markdown_filter %}
-{% block title %}
-Representatives |
-{% endblock %}
+{% block title %}Representatives{% endblock %}
 {% block og_description_content %}
 Democracy Club wants to connect the national to the local.
 {% endblock %}

--- a/democracy_club/settings/testing.py
+++ b/democracy_club/settings/testing.py
@@ -5,3 +5,4 @@ STATICFILES_STORAGE = "pipeline.storage.PipelineStorage"
 
 GOCARDLESS_USE_SANDBOX = True
 GOCARDLESS_ACCESS_TOKEN = "Made Up"
+SITE_TITLE = "Democracy Club"

--- a/democracy_club/templates/about/impact.html
+++ b/democracy_club/templates/about/impact.html
@@ -4,6 +4,7 @@
 {# fmt:off #}
 
 {% block page_heading %}<h1>Our impact</h1>{% endblock page_heading %}
+{% block title %}Our Impact{% endblock title %}
 
 {% block main_content %}
   {% filter markdown %}

--- a/democracy_club/templates/about/index.html
+++ b/democracy_club/templates/about/index.html
@@ -1,7 +1,7 @@
 {% extends "about/about_base.html" %}
 {% load markdown_filter %}
 
-{% block title %}About | {{ block.super }}{% endblock title %}
+{% block title %}About{% endblock title %}
 
 
 {# fmt:off #}

--- a/democracy_club/templates/about/jobs.html
+++ b/democracy_club/templates/about/jobs.html
@@ -1,9 +1,7 @@
 {% extends "about/about_base.html" %}
 {% load markdown_filter %}
 
-{% block title %}
-Jobs |
-{% endblock %}
+{% block title %}Jobs{% endblock %}
 
 {% block page_heading %}<h1>Jobs</h1>{% endblock page_heading %}
 

--- a/democracy_club/templates/about/team.html
+++ b/democracy_club/templates/about/team.html
@@ -3,11 +3,9 @@
 {% load static %}
 
 {# fmt:off #}
-{% block page_heading %}<h1>The Team</h1>{% endblock page_heading %}
+{% block title %}The Team{% endblock title %}
 
-{% block title %}
-  The Team -
-{% endblock %}
+{% block page_heading %}<h1>The Team</h1>{% endblock page_heading %}
 
 {% block main_content %}
   <p>Building and maintaining Democracy Club's services is a long-term commitment, both in the run up to the elections

--- a/democracy_club/templates/base.html
+++ b/democracy_club/templates/base.html
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{% block title %}{% endblock title %} Democracy Club</title>
+    <title>{% block title %}Home{% endblock title %} | Democracy Club</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block extra_site_css %}
       {% stylesheet 'styles' %}
@@ -71,7 +71,6 @@
       <main id="main" tabindex="-1" class="ds-stack">
 
         {% block header %}
-
         {% endblock header %}
 
         {% if messages %}

--- a/democracy_club/templates/contact.html
+++ b/democracy_club/templates/contact.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Contact | {{ block.super }}{% endblock title %}
+{% block title %}Contact{% endblock title %}
 
 {% block page_content %}
     <div class="ds-stack-smaller">

--- a/democracy_club/templates/hermes/post_detail.html
+++ b/democracy_club/templates/hermes/post_detail.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load thumbnail %}
 
-{% block title %}{{ post.subject }} | {{ site_title }}{% endblock title %}
+{% block title %}{{ post.subject }}{% endblock title %}
 
 {% block og_description_content %}{{ post.summary }}{% endblock og_description_content %}
 {% block og_image_content %}{% thumbnail post.hero "690" as im %}{{ im.url }}{% endthumbnail %}{% endblock og_image_content %}

--- a/democracy_club/templates/hermes/post_list.html
+++ b/democracy_club/templates/hermes/post_list.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% load typogrify_tags %}}
-
+{% block title %}Blog{% endblock title %}
 {% block body_class %}class="blog"{% endblock %}
 {% block page_content %}
+
+
 
   <div class="ds-stack">
   <h1>Democracy Club Blog</h1>

--- a/democracy_club/templates/report_base.html
+++ b/democracy_club/templates/report_base.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body_class_attr %}class="report"{% endblock body_class_attr %}
-
+{% block title %}{{ page_title|safe }}{% endblock title %}
 {% block content %}
   <style>
       #toc.sticky details {

--- a/democracy_club/templates/support_us.html
+++ b/democracy_club/templates/support_us.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% block title %}Support us{% endblock title %}
 {% block page_heading %}<h1>Funding</h1>{% endblock page_heading %}
 
 {% block content %}


### PR DESCRIPTION
https://stage.democracyclub.org.uk/

Closes https://github.com/DemocracyClub/Website/issues/520

This work ensures consistent page titles on every site page. For reports, I've used the first item in the table of contents to create the page title. Once https://github.com/DemocracyClub/Website/pull/524 is merged, I will add a test that ensures blog post page titles match the blog post subject. 
