### PR TITLE
Dependabot will ignore boto3 patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     versions:
     - ">= 1.15.a"
     - "< 1.16"
+    update-types: ["version-update:semver-patch"]
   - dependency-name: django
     versions:
     - ">= 3.0.a"


### PR DESCRIPTION
AWS releases patch versions of `boto3` on a daily basis, but we don't need to incorporate these changes on the same schedule. This work ensures a dependabot PR will not be raised for patched versions. 

More info https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/