### PR TITLE
Hotfix/notify on fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@3.1.0
   aws-cli: circleci/aws-cli@3.1
+  slack: circleci/slack@4.1
 
 jobs:
   install_and_update_dependencies:
@@ -125,6 +126,11 @@ jobs:
             sentry-cli releases --org democracy-club-gp new $CIRCLE_SHA1 --project dc-website
             sentry-cli releases --org democracy-club-gp set-commits --auto $CIRCLE_SHA1
             sentry-cli releases --org democracy-club-gp finalize $CIRCLE_SHA1
+      # In the event the deployment has failed, alert the dev team
+      - slack/notify:
+            event: fail
+            template: basic_fail_1
+            channel: $SLACK_DEFAULT_CHANNEL
 workflows:
   version: 2
   test_build_deploy:
@@ -141,12 +147,13 @@ workflows:
           dc-environment: staging
           requires:
             - sam_build
-          context: [ deployment-staging-dc-website ]
+          context: [ deployment-staging-dc-website, slack-secrets ]
           filters: { branches: { only: [ main, master, development ] } }
       - sam_deploy:
           name: sam_deploy_production
           dc-environment: production
           requires:
             - sam_deploy_staging
-          context: [ deployment-production-dc-website ]
+          context: [ deployment-production-dc-website, slack-secrets  ]
           filters: { branches: { only: [ main, master ] } }
+  

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     - ">= 1.15.a"
     - "< 1.16"
     update-types: ["version-update:semver-patch"]
+  - dependency-name: botocore
+    update-types: ["version-update:semver-patch"]
+    
   - dependency-name: django
     versions:
     - ">= 3.0.a"


### PR DESCRIPTION
Ref https://trello.com/c/7Qmm5gtY/3268-make-deploy-fails-more-visible

This work follows on from a sprint retro action to make deploy fails more visible with notifications in Slack. It often happens that we merge work and move the Trello card to done, but then don't notice if a fail occurs on master.

Testing this work can only be done on master (unless we intentionally build in an error to cause a deploy failure); but the CI should check for the accessibility of the required env variables in the CI organisational settings. That said, we have completed several trial and error commits with the config on WCIVF and this work is based on that learning.

I've also added an ignore on `botocore` PRs from dependabot for minor version updates (these are issued daily).