### PR TITLE
Fix filepath to static images

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ django-storages = "==1.13.1"
 djangorestframework = "==3.14.0"
 djhtml = "*"
 aws-wsgi = {file = "https://github.com/DemocracyClub/awsgi/archive/refs/tags/v0.2.8.tar.gz"}
-dc-django-utils = {file = "https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.5.tar.gz"}
+dc-django-utils = {file = "https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.6.tar.gz"}
 dc-signup-form = {file = "https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.1.3.tar.gz"}
 dc-design-system = {file = "https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz"}
 django-typogrify = {file = "https://github.com/matthewn/django-typogrify/archive/refs/tags/v2.0.tar.gz"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "79817bfeff0caa1e404aa28f6063dc3bd972710284affbdd8cd6289f6d6fe061"
+            "sha256": "0c714d79e321736e20c1580782a778a513016b0173f0293fc0124edfabad1edd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -400,10 +400,10 @@
         },
         "djhtml": {
             "hashes": [
-                "sha256:f260cdfe7033b21ebc01961db7e1c8832fd5830ec9af1b0e57f3e1f58deb1bd0"
+                "sha256:f1342abc1a0cacaa7b0371fdbb482d2e67b1e1071f777f1f83f6571240666315"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
+            "version": "==3.0.4"
         },
         "docopt": {
             "hashes": [
@@ -468,11 +468,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe",
-                "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"
+                "sha256:3ee3533e7f6f5023157fbebbd5687bb4b698ce6f305259e0d24b2d7d9efb72bc",
+                "sha256:4102ecd051f6884449e7359e55b38ba6cd7aafb6ef27b8e2b38495a5723ea106"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.18"
+            "version": "==2.5.19"
         },
         "idna": {
             "hashes": [
@@ -1060,11 +1060,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330",
-                "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"
+                "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077",
+                "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.4.0"
+            "version": "==67.6.0"
         },
         "sgmllib3k": {
             "hashes": [
@@ -1208,6 +1208,14 @@
         }
     },
     "develop": {
+        "appnope": {
+            "hashes": [
+                "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
+                "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.3"
+        },
         "asgiref": {
             "hashes": [
                 "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac",
@@ -1404,11 +1412,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:7b225dd6bc33405188f33f77c990bd08057f5c512042f7e0966e026c633ec646",
-                "sha256:fdd9cc16cd7e0d8dfcd2bb19d80c1bca5ce52d79690f93bfbb13916d7ed1cb2e"
+                "sha256:51f37ff9df710159d6d736d0ba1c75e063430a8c806b91334d7794305b5a6114",
+                "sha256:5aaa16fa9cfde7d117eef70b6b293a705021e57158f3fa6b44ed1b70202d2065"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==17.4.0"
+            "version": "==17.6.0"
         },
         "idna": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8d0753cad78a1f20921bb65bc9e391a1741b6a9004f5bf41bfcf34d70b590f13"
+            "sha256": "79817bfeff0caa1e404aa28f6063dc3bd972710284affbdd8cd6289f6d6fe061"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -299,11 +299,11 @@
             "version": "==0.2.4"
         },
         "dc-django-utils": {
-            "file": "https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.5.tar.gz",
+            "file": "https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.6.tar.gz",
             "hashes": [
-                "sha256:9e9043d56d9da5a0b9e333daacc16a981a742982596ac9aece1754ded998c2eb"
+                "sha256:0f742ab80bf097850e0b3b985121623d1fd3ee2e58be41db6192156856ac5b2f"
             ],
-            "version": "==2.1.5"
+            "version": "==2.1.6"
         },
         "dc-signup-form": {
             "file": "https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.1.3.tar.gz",
@@ -400,10 +400,10 @@
         },
         "djhtml": {
             "hashes": [
-                "sha256:534deac3d2e474ccbd6daac0de458a3e0ae20e9c2d4b1ca496258bd62a328a18"
+                "sha256:f260cdfe7033b21ebc01961db7e1c8832fd5830ec9af1b0e57f3e1f58deb1bd0"
             ],
             "index": "pypi",
-            "version": "==3.0.3"
+            "version": "==3.0.2"
         },
         "docopt": {
             "hashes": [
@@ -1060,11 +1060,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
-                "sha256:1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242"
+                "sha256:e5fd0a713141a4a105412233c63dc4e17ba0090c8e8334594ac790ec97792330",
+                "sha256:f106dee1b506dee5102cc3f3e9e68137bbad6d47b616be7991714b0c62204251"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.5.1"
+            "version": "==67.4.0"
         },
         "sgmllib3k": {
             "hashes": [
@@ -1404,11 +1404,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:51f37ff9df710159d6d736d0ba1c75e063430a8c806b91334d7794305b5a6114",
-                "sha256:5aaa16fa9cfde7d117eef70b6b293a705021e57158f3fa6b44ed1b70202d2065"
+                "sha256:7b225dd6bc33405188f33f77c990bd08057f5c512042f7e0966e026c633ec646",
+                "sha256:fdd9cc16cd7e0d8dfcd2bb19d80c1bca5ce52d79690f93bfbb13916d7ed1cb2e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==17.6.0"
+            "version": "==17.4.0"
         },
         "idna": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -43,14 +43,7 @@ New posts are created at `/admin/hermes/post`.
 Blog posts now include tags which correspond to projects, such as
 `representatives`. 
 ## Staging environment
-Deploy to https://stage.democracyclub.org.uk to test/view edits
-Once you have pushed your latest changes to your branch:
-
-`git fetch origin` to get access to the development branch 
-`git checkout development`
-`git rebase master`
-`git merge [YOUR BRANCH NAME]`
-`git push origin development`
+Add your branch to the staging env on .circleci/config to deploy to https://stage.democracyclub.org.uk and test/view edits
 
 ## DC Dependencies
 - `[dc_django_utils]()` is the source code for basic HTML structure, forms


### PR DESCRIPTION
Ref https://trello.com/c/ZaUX8fc3/3277-og-image-preview-fix and https://github.com/DemocracyClub/dc_django_utils/pull/52

This work includes a new version of `dc_utils` that fixes a filepath mismatch that was causing a 404 for the twitter image url as seen here https://democracyclub.org.uk/static/images/twitter_large_summary_card.png


To test: 
The same image url on staging with this PR: https://stage.democracyclub.org.uk/static/images/twitter_large_summary_card.536d3ceb43de.png

### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->

When creating a Pull Request please delete items as necessary, leaving those that are relevant.

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Did I added or updated any new dependencies? Explain why.
- [x] Did I update the package.json and/or Pipfile.lock version if relevant?
- [x] Have I rebased with the latest version of master?
- [x] Update any documentation
