### PR TITLE
Remove www

### DIFF
--- a/democracy_club/templates/for_voters.html
+++ b/democracy_club/templates/for_voters.html
@@ -18,14 +18,14 @@
             <div class="ds-stack">
                 <h3>WhereDoIVote.co.uk</h3>
                 <p>'Where Do I Vote?' tells you the location of your polling station using only your postcode.</p>
-                <p><a href="https://www.wheredoivote.co.uk"><strong>Visit WhereDoIVote.co.uk</strong></a></p>
+                <p><a href="https://wheredoivote.co.uk"><strong>Visit WhereDoIVote.co.uk</strong></a></p>
             </div>
 
             <div class="ds-stack">
                 <h3>WhoCanIVoteFor.co.uk</h3>
                 <p>'Who Can I Vote For?' tells you about elections in the near future, including who will be on
                     your ballot paper.</p>
-                <p><a href="https://www.whocanivotefor.co.uk"><strong>Visit WhoCanIVoteFor.co.uk</strong></a></p>
+                <p><a href="https://whocanivotefor.co.uk"><strong>Visit WhoCanIVoteFor.co.uk</strong></a></p>
             </div>
 
             <div class="ds-stack">


### PR DESCRIPTION
We removed the www. domains on who and where, because we assumed no one was linking to them. Turns out, someone was https://democracyclub.org.uk/voters/ :)

This removes the `www` and the following PRs add redirects: 
https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1523
https://github.com/DemocracyClub/UK-Polling-Stations/pull/5083

To test: the link "Visit WhereDoIVote.co.uk" on `http://localhost:8000/voters/` should now redirect to https://www.wheredoivote.co.uk/ rather than (https:/wheredoivote.co.uk/)

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
-  [x] Have I rebased with the latest version of master?
```
