### PR TITLE
Add sendgrid to lambda variables

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -110,6 +110,7 @@ Resources:
           DATABASE_PASS: !Ref AppPostgresPassword
           FQDN: !Ref FQDN
           STORAGE_BUCKET_NAME: !Ref AppStorageBucketName
+          SENDGRID_API_KEY: !Ref AppSendgridAPIKey
       ReservedConcurrentExecutions: 1
       Events:
         HTTPRequests:
@@ -147,6 +148,7 @@ Resources:
           DATABASE_PASS: !Ref AppPostgresPassword
           FQDN: !Ref FQDN
           STORAGE_BUCKET_NAME: !Ref AppStorageBucketName
+          SENDGRID_API_KEY: !Ref AppSendgridAPIKey
       Events:
         SyncToSendgrid:
           Type: Schedule


### PR DESCRIPTION
Related to https://trello.com/c/umVpqIL6/3345-fix-mailing-list-signup

This change adds the Sendgrid API key to the relevant Lambda functions and attempts to fix the sentry error related to calling the `sync_to_sendgrid` command. 