### PR TITLE
Filter by blog tag

### DIFF
--- a/democracy_club/apps/hermes/admin.py
+++ b/democracy_club/apps/hermes/admin.py
@@ -1,15 +1,45 @@
+from django import forms
 from django.contrib import admin
+from django.contrib.admin.widgets import FilteredSelectMultiple
 from hermes.models import Category, Post
 
 
+class PostAdminForm(forms.ModelForm):
+    class Meta:
+        model = Post
+        fields = "__all__"
+
+    tag_values = [
+        ("wcivf", "WCIVF"),
+        ("case_study", "case_study"),
+        ("research", "research"),
+        ("elections", "elections"),
+        ("councils", "councils"),
+        ("candidates", "candidates"),
+        ("representatives", "representatives"),
+        ("data", "data"),
+        ("WDIV", "WDIV"),
+        ("electionleaflets", "electionleaflets"),
+        ("blog", "blog"),
+    ]
+
+    tags = forms.MultipleChoiceField(
+        choices=tag_values,
+        widget=FilteredSelectMultiple("tags", False),
+        required=False,
+    )
+
+
 class PostAdmin(admin.ModelAdmin):
+    form = PostAdminForm
+
     prepopulated_fields = {
         "slug": ("subject",),
     }
     filter_horizontal = ["author"]
     search_fields = ["subject"]
     search_help_text = "Search by subject (Post title)"
-    list_display = ["subject", "created_on", "category"]
+    list_display = ["subject", "created_on", "category", "tags"]
     list_filter = ["is_published", "author"]
 
 

--- a/democracy_club/apps/hermes/tests/test_views.py
+++ b/democracy_club/apps/hermes/tests/test_views.py
@@ -32,6 +32,21 @@ class PostListViewTestCase(HermesTestCase):
         self.assertNotContains(response, self.post3.subject)
 
 
+class TagPostListViewTestCase(HermesTestCase):
+    def url(self, tag):
+        return super(TagPostListViewTestCase, self).url(
+            "hermes_post_list_by_tag", tag=tag
+        )
+
+    def test_get_queryset(self):
+        """The TagPostListView Context should contain a QuerySet of all Posts
+        with the given tag
+        """
+        response = self.get(self.url("foo"))
+        expected = list(models.Post.objects.for_tag("foo"))
+        self.assertEqual(expected, list(response.context["posts"]))
+
+
 class ArchivePostListViewTestCase(HermesTestCase):
     def url(self, year=None, month=None, day=None):
         if year and month and day:

--- a/democracy_club/apps/hermes/urls.py
+++ b/democracy_club/apps/hermes/urls.py
@@ -1,10 +1,11 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from .feeds import LatestPostFeed
 from .views import (
     ArchivePostListView,
     PostDetail,
     PostListView,
+    TagPostListView,
 )
 
 urlpatterns = [
@@ -34,4 +35,9 @@ urlpatterns = [
         name="hermes_post_list",
     ),
     re_path(r"^feed/$", view=LatestPostFeed(), name="hermes_post_feed"),
+    path(
+        "tag/<slug:tag>/",
+        view=TagPostListView.as_view(),
+        name="hermes_post_list_by_tag",
+    ),
 ]

--- a/democracy_club/apps/hermes/views.py
+++ b/democracy_club/apps/hermes/views.py
@@ -35,6 +35,14 @@ class PostListView(ListView):
         return qs
 
 
+class TagPostListView(PostListView):
+    """Displays posts from a specific Tag"""
+
+    def get_queryset(self):
+        tag = self.kwargs.get("tag", "")
+        return self.model.objects.for_tag(tag)
+
+
 class CategoryPostListView(PostListView):
     """Displays posts from a specific Category"""
 

--- a/democracy_club/assets/scss/styles.scss
+++ b/democracy_club/assets/scss/styles.scss
@@ -226,3 +226,8 @@ ul > li > ul {
   column-gap: $s2;
   list-style: none;
 }
+
+.blog-tag {
+  // # show them inline rather than as a list
+  display: inline;
+}

--- a/democracy_club/templates/hermes/post_detail.html
+++ b/democracy_club/templates/hermes/post_detail.html
@@ -32,6 +32,14 @@
                     {% endfor %}
                 </address>
                 on <time pubdate datetime="{{post.modified_on|date:"c"}}" title="{{post.created_on|date:"jS E Y"}}">{{post.created_on|date:"jS E Y"}}</time>
+                {% if post.tags %}
+                    <span aria-hidden="true">🏷️</span>
+                    {% for tag in post.tags %}
+                        <ul>
+                            <li class="blog-tag"><a href="{% url 'hermes_post_list_by_tag' tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}</li>
+                        </ul>
+                    {% endfor %}
+                {% endif %}
             </div>
 
         </header>

--- a/democracy_club/templates/hermes/post_list.html
+++ b/democracy_club/templates/hermes/post_list.html
@@ -24,6 +24,12 @@
                     </address>
                     on <time pubdate datetime="{{post.modified_on|date:"c"}}" title="{{post.created_on|date:"jS E Y"}}">{{post.created_on|date:"jS E Y"}}</time>
                 </div>
+                <div>
+                    <span aria-hidden="true">🏷️</span>
+                    {% for tag in post.tags %}
+                        <a href="{% url 'hermes_post_list_by_tag' tag %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                </div>
                 {{ post.rendered_summary|safe|typogrify }}
                 <a class="ds-cta ds-cta-blue" href="{{ post.get_absolute_url }}">Read more</a>
             </article>

--- a/democracy_club/urls.py
+++ b/democracy_club/urls.py
@@ -67,6 +67,11 @@ urlpatterns = [
         name="case_studies",
     ),
     path(
+        "research/media/",
+        TemplateView.as_view(template_name="research/media.html"),
+        name="media",
+    ),
+    path(
         "research/impact/",
         TemplateView.as_view(template_name="research/impact.html"),
         name="impact",


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/Website/issues/658

-Render tags on post list and detail
-Fix filtering
-Add tags to Post list admin view
-Change tag widget to **multiselect** with hard coded tag values

To test, edit or create 2 blog post sin the admin view. Choose a common tag for both posts as well as a unique tag for each. Save the posts and view in the list. Click the unique tags to filter. 

On blog list
![Screenshot 2023-10-04 at 3 59 20 PM](https://github.com/DemocracyClub/Website/assets/7017118/b4b14f1e-6144-4fba-a125-d08c161381c1)


On blog detail
![Screenshot 2023-10-04 at 3 59 26 PM](https://github.com/DemocracyClub/Website/assets/7017118/41d0c86f-145f-461c-838e-ca532d0be1c1)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205591747849774
  - https://app.asana.com/0/0/1205277321114260