### PR TITLE
Add validation for case_studies page

### DIFF
--- a/democracy_club/apps/core/signals.py
+++ b/democracy_club/apps/core/signals.py
@@ -8,4 +8,4 @@ from hermes.models import Post
 def blog_url_invalidation_handler(sender, **kwargs):
     instance = kwargs["instance"]
     path = instance.get_absolute_url()
-    invalidate_paths([path, "/blog/", "/"])
+    invalidate_paths([path, "/blog/", "/", "/research/case_studies/"])


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1205677928057011/f

This change ensures the content on `/research/case_studies` is visible on load. 