### PR TITLE
fix link to widget embed docs

### DIFF
--- a/democracy_club/apps/projects/templates/projects/polling-stations/home.html
+++ b/democracy_club/apps/projects/templates/projects/polling-stations/home.html
@@ -28,7 +28,7 @@ The finder regularly receives over a million searches per election.
 If you work at a council, <a href="{% url 'projects:polling_data_upload' %}">find out how to send us data</a>.
 
 Find out how to
-<a href="{% url 'projects:polling_data_upload' %}">use the widget on your website or in an app</a>.
+<a href="{% url 'projects:election_widget' %}">use the widget on your website or in an app</a>.
 
 
 {% endfilter %}


### PR DESCRIPTION
The "use the widget on your website or in an app" link on https://democracyclub.org.uk/projects/polling-stations/ currently points to the upload data page.

This PR fixes it.
